### PR TITLE
fix command not found issue with `buffalo db`

### DIFF
--- a/buffalo.plugin.zsh
+++ b/buffalo.plugin.zsh
@@ -86,7 +86,7 @@ _buffalo_db() {
 		{-e=,--env=}"[]:string"\
 		{-h,--help}"[help for db]"\
 		{-p=,--path=}"[Path to the migrations folder (default \\\"./migrations\\\")]:string"\
-		{-v,--version}"[Show version information]"
+		{-v,--version}"[Show version information]"\
 		"*::arg:->args"
 
 	case $line[1] in


### PR DESCRIPTION
When attempting to tab complete `buffalo db` commands was getting a command not found error